### PR TITLE
Switch test schema and polish voucher UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,18 @@ $(BUILD)/vendorstest.o : $(SRC)/vendorstest.cpp
 
 vendors_sa : $(BUILD)/vendors.o $(BUILD)/vendorstest.o
 	$(CXX) $(CXX_STD) -o vendors_sa $?
+
+# =============================================================================
+# Database targets
+# =============================================================================
+PG_BIN  := /opt/homebrew/Cellar/postgresql@18/18.1_1/bin
+PG_CONN := -h localhost -p 5432 -U postgres -d finance
+
+.PHONY: refresh-test-db
+
+## Recreate finance_tst schema and load last-100-voucher subset from finance.
+## Reads PGPASSWORD from the environment (export it or prefix the make call).
+## Usage: PGPASSWORD='<pass>' make refresh-test-db
+refresh-test-db:
+	PGPASSWORD="$(PGPASSWORD)" $(PG_BIN)/psql $(PG_CONN) -f db/01_recreate_finance_tst.sql
+	PGPASSWORD="$(PGPASSWORD)" $(PG_BIN)/psql $(PG_CONN) -f db/02_load_finance_tst.sql

--- a/MyFinance/finance.py
+++ b/MyFinance/finance.py
@@ -44,6 +44,19 @@ def create_app(test_config=None):
     if 'pg_utils' not in app.extensions:
         app.extensions['pg_utils'] = PgUtils(app.config['PGURI'])
 
+    @app.context_processor
+    def inject_environment_indicator():
+        flask_env = (os.environ.get('FLASK_ENV') or os.environ.get('FLASH_ENV') or '').strip().lower()
+        if flask_env in ('test', 'testing'):
+            return {
+                'environment_label': 'TECHTEST',
+                'environment_badge_class': 'bg-danger text-white'
+            }
+        return {
+            'environment_label': 'PRODUCTION',
+            'environment_badge_class': 'bg-success text-white'
+        }
+
     # The Home page
     @app.route('/')
     @app.route('/home')

--- a/MyFinance/models/base.py
+++ b/MyFinance/models/base.py
@@ -1,0 +1,26 @@
+import os
+
+from sqlalchemy import MetaData
+from sqlalchemy.orm import declarative_base
+
+
+def get_model_schema() -> str:
+    """Return schema for ORM metadata based on environment.
+
+    Priority:
+    1) MYFINANCE_DB_SCHEMA override when explicitly provided.
+    2) finance_tst when running in test/testing env.
+    3) finance for all other environments.
+    """
+    schema_override = os.getenv("MYFINANCE_DB_SCHEMA")
+    if schema_override:
+        return schema_override
+
+    flask_env = (os.getenv("FLASK_ENV") or os.getenv("FLASH_ENV") or "").strip().lower()
+    if flask_env in {"test", "testing"}:
+        return "finance_tst"
+
+    return "finance"
+
+
+Base = declarative_base(metadata=MetaData(schema=get_model_schema()))

--- a/MyFinance/models/entities.py
+++ b/MyFinance/models/entities.py
@@ -1,8 +1,8 @@
 import sys
 sys.path.append('/Users/edmundlskoviak/Documents/repos/finance_cmd')
 
-from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer, MetaData, String, Text, create_engine)
-from sqlalchemy.orm import (relationship, Mapped, mapped_column, declarative_base)
+from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer, String, Text, create_engine)
+from sqlalchemy.orm import (relationship, Mapped, mapped_column)
 
 from MyFinance.models.vendors import Vendors
 #from MyFinance.models.vouchers import Voucher
@@ -13,7 +13,7 @@ from datetime import datetime
 from pathlib import Path
 import os
 
-Base = declarative_base(metadata=MetaData(schema='finance'))
+from MyFinance.models.base import Base
 
 class ExternalAccounts(Base):
     """SQLAlchemy class to model the table `external_accounts`

--- a/MyFinance/models/payables.py
+++ b/MyFinance/models/payables.py
@@ -1,8 +1,7 @@
 import sys
 sys.path.append('/Users/edmundlskoviak/Documents/repos/finance_cmd')
 
-from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer, MetaData, String, Text, create_engine)
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer, String, Text, create_engine)
 from sqlalchemy.orm import (relationship, Mapped, mapped_column)
 
 from MyFinance.models.entities import ExternalAccounts
@@ -15,7 +14,7 @@ from datetime import datetime
 from pathlib import Path
 import os
 
-Base = declarative_base(metadata=MetaData(schema='finance'))
+from MyFinance.models.base import Base
 
 class Liabilities(Base):
     """Liablities Class

--- a/MyFinance/models/user.py
+++ b/MyFinance/models/user.py
@@ -1,8 +1,7 @@
-from sqlalchemy import (Column, Integer, MetaData, String)
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import (Column, Integer, String)
 #from sqlalchemy.orm import relationship
 
-Base = declarative_base(metadata=MetaData(schema='finance'))
+from MyFinance.models.base import Base
 
 class User(Base):
     """The user table is used to provided authorization to the app
@@ -11,6 +10,7 @@ class User(Base):
         base (_type_): _description_
     """
     __tablename__ = "user"
+    __table_args__ = {'schema': 'finance'}
 
     id = Column(Integer, primary_key=True)
     username = Column(String(50), nullable=False)

--- a/MyFinance/models/vendors.py
+++ b/MyFinance/models/vendors.py
@@ -1,8 +1,7 @@
-from sqlalchemy import (Column, Integer, MetaData, String)
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import (Column, Integer, String)
 #from sqlalchemy.orm import relationship
 
-Base = declarative_base(metadata=MetaData(schema='finance'))
+from MyFinance.models.base import Base
 
 class Vendors(Base):
     """The Vendors class--a collection of the system vendors

--- a/MyFinance/models/vouchers.py
+++ b/MyFinance/models/vouchers.py
@@ -1,11 +1,11 @@
 import sys
 sys.path.append('/Users/edmundlskoviak/Documents/repos/finance_cmd')
 
-from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer, MetaData,
+from sqlalchemy import (Column, DateTime, Float, ForeignKey, Integer,
                         String, Text, create_engine)
-from sqlalchemy.orm import (relationship, Mapped, mapped_column, declarative_base)
+from sqlalchemy.orm import relationship
 
-Base = declarative_base(metadata=MetaData(schema='finance'))
+from MyFinance.models.base import Base
 from MyFinance.models.entities import ExternalAccounts, PaymentType, Company
 from MyFinance.models.vendors import Vendors
 

--- a/MyFinance/templates/common/forms.html
+++ b/MyFinance/templates/common/forms.html
@@ -6,10 +6,10 @@
     </div>
 {%- endmacro %}
 
-{% macro select(name, id, option_list=None, option_key=None, option_value=None, label='label', helptext='help') -%}
+{% macro select(name, id, option_list=None, option_key=None, option_value=None, label='label', helptext='help', selected_value=None) -%}
     <select name="{{name}}" id="{{id}}" class="form-select">
         {% for item in option_list %}
-            <option value="{{item[option_key]}}">{{item[option_value]}}</option>
+            <option value="{{item[option_key]}}" {% if selected_value is not none and item[option_key] == selected_value %}selected{% endif %}>{{item[option_value]}}</option>
         {% endfor %}
     </select>
     <label class="ps-2" for="{{id}}">{{label}}</label>

--- a/MyFinance/templates/common/forms.html
+++ b/MyFinance/templates/common/forms.html
@@ -6,10 +6,10 @@
     </div>
 {%- endmacro %}
 
-{% macro select(name, id, option_list=None, option_key=None, option_value=None, label='label', helptext='help', selected_value=None) -%}
-    <select name="{{name}}" id="{{id}}" class="form-select">
+{% macro select(name, id, option_list=None, option_key=None, option_value=None, label='label', helptext='help', selected_value=None, modifiers='') -%}
+    <select name="{{name}}" id="{{id}}" class="form-select" {{modifiers}}>
         {% for item in option_list %}
-            <option value="{{item[option_key]}}" {% if selected_value is not none and item[option_key] == selected_value %}selected{% endif %}>{{item[option_value]}}</option>
+            <option value="{{item[option_key]}}" {% if selected_value is not none and item[option_key]|string == selected_value|string %}selected{% endif %}>{{item[option_value]}}</option>
         {% endfor %}
     </select>
     <label class="ps-2" for="{{id}}">{{label}}</label>

--- a/MyFinance/templates/navigation.html
+++ b/MyFinance/templates/navigation.html
@@ -1,6 +1,7 @@
 <nav class="navbar navbar-expand-md navbar-light bg-light">
     <div class="container-fluid">
         <a class="navbar-brand" href={{ url_for("home") }}>MyFinance</a>
+        <span class="badge {{ environment_badge_class }} me-2">{{ environment_label }}</span>
         <span>
             {% if g.user == None %}
             <a href={{ url_for("auth.login")}}>Login</a>

--- a/MyFinance/templates/voucher/voucher_entry.html
+++ b/MyFinance/templates/voucher/voucher_entry.html
@@ -13,51 +13,51 @@ Voucher Entry
         <div class="row gx-2 gy-1">
             <div class="col-md-3 form-floating">
                 {{ input_control('voucher_date', value=None,
-                  modifiers='autofocus required', label='Item Date', helptext='MM/DD/YY HH:MM TZ') }}                
+                                    modifiers='autofocus required tabindex="1"', label='Item Date', helptext='MM/DD/YY HH:MM TZ') }}                
             </div>
             <div class="col-md-3 form-floating">
                 {{ select_control('company', id='company', option_list=company_list, option_key='id', option_value='company_name',
-                    label='Company', helptext='Select the company to book the voucher to' )}}
+                                        label='Company', helptext='Select the company to book the voucher to', modifiers='tabindex="2"' )}}
             </div>
             <div class="col-md-6 form-floating">
                 {{ input_control('voucher_ref', value=None,
-                  label='Voucher Reference', helptext='Enter identifying information from the voucher, such as the voucher or invoice number') }}
+                                    modifiers='tabindex="3"', label='Voucher Reference', helptext='Enter identifying information from the voucher, such as the voucher or invoice number') }}
             </div>
         </div>
 
         <div class="row gx-2 gy-1">
             <div class="col-md-6 form-floating">
                 {{ select_control('vendor', id='vendor', option_list=vendor_list, option_key='vendor_number', option_value='vendor_short_desc', 
-                  label='Vendor', helptext='Enter the Vendor') }}
+                                    label='Vendor', helptext='Enter the Vendor', modifiers='tabindex="4"') }}
             </div>
             <div class="col-md-3 form-floating">
                 {{ select_control('voucher_type', id='voucher_type', option_list=voucher_type_list, option_key='type_code', option_value='type_text',
-                label='Type', helptext='The type of the voucher', selected_value=selected_voucher_type) }}
+                                label='Type', helptext='The type of the voucher', selected_value=selected_voucher_type, modifiers='tabindex="5"') }}
             </div>
             <div class="col-md-3 form-floating">
                 {{ input_control('voucher_amt', type='number', value=None,
-                  label='Amount', helptext='The amount of the voucher' ) }}
+                                    modifiers='tabindex="6"', label='Amount', helptext='The amount of the voucher' ) }}
             </div>
         </div>
 
         <div class="row gx-2 gy-1">
             <div class="col-md-4 form-floating">
                 {{ select_control('payment_type', id='voucher-pay-type-select', option_list=payment_type_list, option_key='payment_type_id', 
-                  option_value='payment_type_text', label='Pmt Type', helptext='The type of the payment')}}
+                  option_value='payment_type_text', label='Pmt Type', helptext='The type of the payment', modifiers='tabindex="7"')}}
             </div>
             <div class="col-md-4 form-floating">
                 {{ select_control('pmt_account', option_list=account_list, option_key='external_account_id', option_value='account_name',
-                    label='Payment Source', helptext='The source of the payment')}}
+                    label='Payment Source', helptext='The source of the payment', modifiers='tabindex="8"')}}
             </div>
         </div>
 
         <div class="row gx-2 gy-1">
             <div class="col-md-8 form-floating">
-                {{ input_control('payment_ref', value=None, label='Payment Reference', 
+                {{ input_control('payment_ref', value=None, modifiers='tabindex="9"', label='Payment Reference', 
                   helptext='Enter additional information, such as location, the nature of the service or the vendor for a generic vendor which will appear in the ledger.') }}
             </div>
             <div class="col-md-4">
-                <input type="submit" value="Submit" class="btn btn-primary mb-3">
+                <input type="submit" value="Submit" class="btn btn-primary mb-3" id="voucher-submit" tabindex="10">
             </div>
         </div>
     </form>

--- a/MyFinance/templates/voucher/voucher_entry.html
+++ b/MyFinance/templates/voucher/voucher_entry.html
@@ -9,7 +9,7 @@ Voucher Entry
 {% block content %}
 {% from 'common/forms.html' import input as input_control, select as select_control %}
 <div class="container-md">
-    <form action="/voucher/voucher_result" method="POST">
+    <form action="/voucher/voucher_result" method="POST" id="voucher-entry-form">
         <div class="row gx-2 gy-1">
             <div class="col-md-3 form-floating">
                 {{ input_control('voucher_date', value=None,
@@ -32,7 +32,7 @@ Voucher Entry
             </div>
             <div class="col-md-3 form-floating">
                 {{ select_control('voucher_type', id='voucher_type', option_list=voucher_type_list, option_key='type_code', option_value='type_text',
-                  label='Type', helptext='The type of the voucher') }}
+                label='Type', helptext='The type of the voucher', selected_value=selected_voucher_type) }}
             </div>
             <div class="col-md-3 form-floating">
                 {{ input_control('voucher_amt', type='number', value=None,
@@ -82,6 +82,23 @@ Voucher Entry
 {% endblock %}
 {% block script %}
 <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const voucherDateInput = document.getElementById('voucher_date');
+        if (voucherDateInput) {
+            voucherDateInput.focus();
+        }
+
+        const voucherForm = document.getElementById('voucher-entry-form');
+        if (voucherForm) {
+            voucherForm.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' && event.target.tagName !== 'TEXTAREA') {
+                    event.preventDefault();
+                    voucherForm.requestSubmit();
+                }
+            });
+        }
+    });
+
     const toastTrigger = document.getElementById('liveToastBtn')
     const toastLiveExample = document.getElementById('liveToast')
     if (toastTrigger) {

--- a/MyFinance/voucher.py
+++ b/MyFinance/voucher.py
@@ -49,13 +49,22 @@ def enter_voucher():
     """
     pg_utils = get_pg_utils()
     session['voucher_amt'] = 0
+    voucher_types = pg_utils.get_voucher_types()
+    selected_voucher_type = None
+    for voucher_type in voucher_types:
+        type_text = str(voucher_type.get('type_text', '')).strip().lower()
+        if type_text == 'paper':
+            selected_voucher_type = voucher_type.get('type_code')
+            break
+
     return render_template(
         'voucher/voucher_entry.html',
         title='Voucher Entry',
         description='Enter voucher data',
         vendor_list=pg_utils.get_vendors(),
         account_list=pg_utils.get_external_accounts(),
-        voucher_type_list=pg_utils.get_voucher_types(),
+        voucher_type_list=voucher_types,
+        selected_voucher_type=selected_voucher_type,
         payment_type_list=pg_utils.get_payment_types(),
         company_list=pg_utils.get_company()
     )

--- a/MyFinance/voucher.py
+++ b/MyFinance/voucher.py
@@ -53,7 +53,7 @@ def enter_voucher():
     selected_voucher_type = None
     for voucher_type in voucher_types:
         type_text = str(voucher_type.get('type_text', '')).strip().lower()
-        if type_text == 'paper':
+        if 'paper' in type_text:
             selected_voucher_type = voucher_type.get('type_code')
             break
 

--- a/db/01_recreate_finance_tst.sql
+++ b/db/01_recreate_finance_tst.sql
@@ -1,0 +1,164 @@
+-- =============================================================================
+-- 01_recreate_finance_tst.sql
+-- Drops and recreates all tables in finance_tst matching the finance schema.
+-- Scope: MVP subset for UI tech-testing (Issue #34)
+--   Lookups : company, payment_type, voucher_type, vendors, external_accounts
+--   Transactions: voucher, voucher_detail, accounts_payable, asset_transfer
+-- Run as: psql -d finance -f db/01_recreate_finance_tst.sql
+-- =============================================================================
+
+\echo '== [1/4] Dropping existing tables =='
+
+DROP TABLE IF EXISTS finance_tst.accounts_payable  CASCADE;
+DROP TABLE IF EXISTS finance_tst.asset_transfer     CASCADE;
+DROP TABLE IF EXISTS finance_tst.voucher_detail     CASCADE;
+DROP TABLE IF EXISTS finance_tst.voucher            CASCADE;
+DROP TABLE IF EXISTS finance_tst.external_accounts  CASCADE;
+DROP TABLE IF EXISTS finance_tst.vendors            CASCADE;
+DROP TABLE IF EXISTS finance_tst.payment_type       CASCADE;
+DROP TABLE IF EXISTS finance_tst.voucher_type       CASCADE;
+DROP TABLE IF EXISTS finance_tst.company            CASCADE;
+-- leftover tables from previous partial setup
+DROP TABLE IF EXISTS finance_tst.assets             CASCADE;
+DROP TABLE IF EXISTS finance_tst.external_account_id CASCADE;
+
+\echo '== [2/4] Dropping existing sequences =='
+
+DROP SEQUENCE IF EXISTS finance_tst.vendors_vendor_number_seq                 CASCADE;
+DROP SEQUENCE IF EXISTS finance_tst.external_accounts_external_account_id_seq CASCADE;
+DROP SEQUENCE IF EXISTS finance_tst.payment_type_payment_type_id_seq          CASCADE;
+DROP SEQUENCE IF EXISTS finance_tst.voucher_type_type_code_seq                CASCADE;
+DROP SEQUENCE IF EXISTS finance_tst.company_id_seq                            CASCADE;
+DROP SEQUENCE IF EXISTS finance_tst.voucher_voucher_number_seq                CASCADE;
+DROP SEQUENCE IF EXISTS finance_tst.voucher_detail_id_seq                     CASCADE;
+DROP SEQUENCE IF EXISTS finance_tst.accounts_payable_id_seq                   CASCADE;
+DROP SEQUENCE IF EXISTS finance_tst.asset_transfer_id_seq                     CASCADE;
+
+\echo '== [3/4] Creating sequences =='
+
+CREATE SEQUENCE finance_tst.vendors_vendor_number_seq                 START 1;
+CREATE SEQUENCE finance_tst.external_accounts_external_account_id_seq START 1;
+CREATE SEQUENCE finance_tst.payment_type_payment_type_id_seq          START 1;
+CREATE SEQUENCE finance_tst.voucher_type_type_code_seq                START 1;
+CREATE SEQUENCE finance_tst.company_id_seq                            START 1;
+CREATE SEQUENCE finance_tst.voucher_voucher_number_seq                START 1;
+CREATE SEQUENCE finance_tst.voucher_detail_id_seq                     START 1;
+CREATE SEQUENCE finance_tst.accounts_payable_id_seq                   START 1;
+CREATE SEQUENCE finance_tst.asset_transfer_id_seq                     START 1;
+
+\echo '== [4/4] Creating tables =='
+
+-- ----------------------------------------------------------------------------
+-- Lookups (no FK dependencies within this set)
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE finance_tst.company (
+    id             integer          NOT NULL DEFAULT nextval('finance_tst.company_id_seq'),
+    company_number integer          NOT NULL,
+    company_name   character varying NOT NULL,
+    CONSTRAINT company_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE finance_tst.payment_type (
+    payment_type_id   integer               NOT NULL DEFAULT nextval('finance_tst.payment_type_payment_type_id_seq'),
+    payment_type_text character varying(20) NOT NULL,
+    CONSTRAINT payment_type_pkey PRIMARY KEY (payment_type_id)
+);
+
+CREATE TABLE finance_tst.voucher_type (
+    type_code integer               NOT NULL DEFAULT nextval('finance_tst.voucher_type_type_code_seq'),
+    type_text character varying(25) NOT NULL,
+    CONSTRAINT voucher_type_pkey PRIMARY KEY (type_code)
+);
+
+CREATE TABLE finance_tst.vendors (
+    vendor_number     integer               NOT NULL DEFAULT nextval('finance_tst.vendors_vendor_number_seq'),
+    vendor_short_desc character varying(30) NOT NULL,
+    vendor_address    character varying(60),
+    CONSTRAINT vendors_pkey PRIMARY KEY (vendor_number)
+);
+
+CREATE TABLE finance_tst.external_accounts (
+    external_account_id integer                NOT NULL DEFAULT nextval('finance_tst.external_accounts_external_account_id_seq'),
+    account_name        character varying(100) NOT NULL,
+    account_number      character varying(30)  NOT NULL,
+    qualified           character varying(1),
+    account_type        character(2),
+    CONSTRAINT external_accounts_pkey PRIMARY KEY (external_account_id)
+);
+
+-- ----------------------------------------------------------------------------
+-- Transactions (FK to lookups above)
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE finance_tst.voucher (
+    voucher_number    integer                  NOT NULL DEFAULT nextval('finance_tst.voucher_voucher_number_seq'),
+    voucher_date      timestamp with time zone NOT NULL,
+    voucher_ref       character varying(50),
+    voucher_amt       numeric(10,2)            NOT NULL,
+    voucher_type_id   integer,
+    vendor_number     integer,
+    payment_type_id   integer,
+    payment_ref       character varying(50),
+    payment_source_id integer,
+    company_id        integer                  NOT NULL,
+    CONSTRAINT voucher_pkey PRIMARY KEY (voucher_number),
+    CONSTRAINT voucher_company_id_fkey          FOREIGN KEY (company_id)
+        REFERENCES finance_tst.company(id),
+    CONSTRAINT voucher_payment_source_id_fkey   FOREIGN KEY (payment_source_id)
+        REFERENCES finance_tst.external_accounts(external_account_id),
+    CONSTRAINT voucher_payment_type_id_fkey     FOREIGN KEY (payment_type_id)
+        REFERENCES finance_tst.payment_type(payment_type_id),
+    CONSTRAINT voucher_vendor_number_fkey       FOREIGN KEY (vendor_number)
+        REFERENCES finance_tst.vendors(vendor_number),
+    CONSTRAINT voucher_voucher_type_id_fkey     FOREIGN KEY (voucher_type_id)
+        REFERENCES finance_tst.voucher_type(type_code)
+);
+
+CREATE TABLE finance_tst.voucher_detail (
+    id               integer               NOT NULL DEFAULT nextval('finance_tst.voucher_detail_id_seq'),
+    voucher_number   integer,
+    split_seq_number integer               NOT NULL,
+    account_number   character varying(10) NOT NULL,
+    amount           numeric(10,2)         NOT NULL,
+    dimension_1      character varying(20),
+    dimension_2      character varying,
+    memo             text,
+    CONSTRAINT voucher_detail_pkey PRIMARY KEY (id),
+    CONSTRAINT voucher_detail_voucher_number_fkey FOREIGN KEY (voucher_number)
+        REFERENCES finance_tst.voucher(voucher_number)
+);
+
+CREATE TABLE finance_tst.accounts_payable (
+    id                 integer                      NOT NULL DEFAULT nextval('finance_tst.accounts_payable_id_seq'),
+    vendor_number      integer,
+    stmt_dt            timestamp without time zone  NOT NULL,
+    stmt_amt           double precision             NOT NULL,
+    payment_due_dt     timestamp without time zone  NOT NULL,
+    payment_source_id  integer,
+    payment_voucher_id integer,
+    invoice_id         character varying(25),
+    CONSTRAINT accounts_payable_pkey PRIMARY KEY (id),
+    CONSTRAINT accounts_payable_payment_source_id_fkey  FOREIGN KEY (payment_source_id)
+        REFERENCES finance_tst.external_accounts(external_account_id),
+    CONSTRAINT accounts_payable_payment_voucher_id_fkey FOREIGN KEY (payment_voucher_id)
+        REFERENCES finance_tst.voucher(voucher_number),
+    CONSTRAINT accounts_payable_vendor_number_fkey      FOREIGN KEY (vendor_number)
+        REFERENCES finance_tst.vendors(vendor_number)
+);
+
+CREATE TABLE finance_tst.asset_transfer (
+    id                      integer                  NOT NULL DEFAULT nextval('finance_tst.asset_transfer_id_seq'),
+    transfer_date           timestamp with time zone NOT NULL,
+    transfer_amount         numeric(10,2)            NOT NULL,
+    src_external_account_id integer,
+    tgt_external_account_id integer,
+    memo                    text,
+    CONSTRAINT asset_transfer_pkey PRIMARY KEY (id),
+    CONSTRAINT asset_transfer_src_external_account_id_fkey FOREIGN KEY (src_external_account_id)
+        REFERENCES finance_tst.external_accounts(external_account_id),
+    CONSTRAINT asset_transfer_tgt_external_account_id_fkey FOREIGN KEY (tgt_external_account_id)
+        REFERENCES finance_tst.external_accounts(external_account_id)
+);
+
+\echo '== finance_tst schema recreation complete =='

--- a/db/02_load_finance_tst.sql
+++ b/db/02_load_finance_tst.sql
@@ -1,0 +1,126 @@
+-- =============================================================================
+-- 02_load_finance_tst.sql
+-- Loads a working subset from finance into finance_tst (Issue #34)
+--
+-- Strategy:
+--   Lookups         : full copy (all rows — these are small reference tables)
+--   voucher         : last 100 rows by voucher_number DESC
+--   voucher_detail  : all detail rows for those 100 vouchers
+--   accounts_payable: rows whose payment_voucher_id is NULL or in loaded set
+--   asset_transfer  : full copy (small table)
+--
+-- Run AFTER 01_recreate_finance_tst.sql
+-- Run as: psql -d finance -f db/02_load_finance_tst.sql
+-- =============================================================================
+
+BEGIN;
+
+\echo '== [1/7] Loading lookup: company =='
+INSERT INTO finance_tst.company (id, company_number, company_name)
+SELECT id, company_number, company_name
+FROM finance.company;
+
+\echo '== [2/7] Loading lookup: payment_type =='
+INSERT INTO finance_tst.payment_type (payment_type_id, payment_type_text)
+SELECT payment_type_id, payment_type_text
+FROM finance.payment_type;
+
+\echo '== [3/7] Loading lookup: voucher_type =='
+INSERT INTO finance_tst.voucher_type (type_code, type_text)
+SELECT type_code, type_text
+FROM finance.voucher_type;
+
+\echo '== [4/7] Loading lookup: vendors (full) =='
+INSERT INTO finance_tst.vendors (vendor_number, vendor_short_desc, vendor_address)
+SELECT vendor_number, vendor_short_desc, vendor_address
+FROM finance.vendors;
+
+\echo '== [5/7] Loading lookup: external_accounts (full) =='
+INSERT INTO finance_tst.external_accounts (
+    external_account_id, account_name, account_number, qualified, account_type)
+SELECT external_account_id, account_name, account_number, qualified, account_type
+FROM finance.external_accounts;
+
+\echo '== [6/7] Loading transactions =='
+
+-- voucher: last 100 by voucher_number (highest = most recent)
+INSERT INTO finance_tst.voucher (
+    voucher_number, voucher_date, voucher_ref, voucher_amt,
+    voucher_type_id, vendor_number, payment_type_id,
+    payment_ref, payment_source_id, company_id)
+SELECT
+    voucher_number, voucher_date, voucher_ref, voucher_amt,
+    voucher_type_id, vendor_number, payment_type_id,
+    payment_ref, payment_source_id, company_id
+FROM finance.voucher
+ORDER BY voucher_number DESC
+LIMIT 100;
+
+-- voucher_detail: all lines for the 100 vouchers loaded above
+INSERT INTO finance_tst.voucher_detail (
+    id, voucher_number, split_seq_number, account_number,
+    amount, dimension_1, dimension_2, memo)
+SELECT
+    id, voucher_number, split_seq_number, account_number,
+    amount, dimension_1, dimension_2, memo
+FROM finance.voucher_detail
+WHERE voucher_number IN (SELECT voucher_number FROM finance_tst.voucher);
+
+-- accounts_payable: only rows whose payment_voucher_id references a loaded voucher
+-- (or is NULL — unpaid statements have no voucher yet)
+INSERT INTO finance_tst.accounts_payable (
+    id, vendor_number, stmt_dt, stmt_amt, payment_due_dt,
+    payment_source_id, payment_voucher_id, invoice_id)
+SELECT
+    id, vendor_number, stmt_dt, stmt_amt, payment_due_dt,
+    payment_source_id, payment_voucher_id, invoice_id
+FROM finance.accounts_payable
+WHERE payment_voucher_id IS NULL
+   OR payment_voucher_id IN (SELECT voucher_number FROM finance_tst.voucher);
+
+-- asset_transfer: full copy (small table)
+INSERT INTO finance_tst.asset_transfer (
+    id, transfer_date, transfer_amount,
+    src_external_account_id, tgt_external_account_id, memo)
+SELECT
+    id, transfer_date, transfer_amount,
+    src_external_account_id, tgt_external_account_id, memo
+FROM finance.asset_transfer;
+
+\echo '== [7/7] Resetting sequences to max loaded values =='
+
+SELECT setval('finance_tst.company_id_seq',
+    COALESCE((SELECT MAX(id) FROM finance_tst.company), 1));
+SELECT setval('finance_tst.payment_type_payment_type_id_seq',
+    COALESCE((SELECT MAX(payment_type_id) FROM finance_tst.payment_type), 1));
+SELECT setval('finance_tst.voucher_type_type_code_seq',
+    COALESCE((SELECT MAX(type_code) FROM finance_tst.voucher_type), 1));
+SELECT setval('finance_tst.vendors_vendor_number_seq',
+    COALESCE((SELECT MAX(vendor_number) FROM finance_tst.vendors), 1));
+SELECT setval('finance_tst.external_accounts_external_account_id_seq',
+    COALESCE((SELECT MAX(external_account_id) FROM finance_tst.external_accounts), 1));
+SELECT setval('finance_tst.voucher_voucher_number_seq',
+    COALESCE((SELECT MAX(voucher_number) FROM finance_tst.voucher), 1));
+SELECT setval('finance_tst.voucher_detail_id_seq',
+    COALESCE((SELECT MAX(id) FROM finance_tst.voucher_detail), 1));
+SELECT setval('finance_tst.accounts_payable_id_seq',
+    COALESCE((SELECT MAX(id) FROM finance_tst.accounts_payable), 1));
+SELECT setval('finance_tst.asset_transfer_id_seq',
+    COALESCE((SELECT MAX(id) FROM finance_tst.asset_transfer), 1));
+
+COMMIT;
+
+\echo '== Load complete — row counts =='
+
+SELECT table_name, row_count FROM (
+    SELECT 'company'          AS table_name, COUNT(*) AS row_count FROM finance_tst.company          UNION ALL
+    SELECT 'payment_type',                   COUNT(*)              FROM finance_tst.payment_type      UNION ALL
+    SELECT 'voucher_type',                   COUNT(*)              FROM finance_tst.voucher_type      UNION ALL
+    SELECT 'vendors',                        COUNT(*)              FROM finance_tst.vendors           UNION ALL
+    SELECT 'external_accounts',              COUNT(*)              FROM finance_tst.external_accounts UNION ALL
+    SELECT 'voucher',                        COUNT(*)              FROM finance_tst.voucher           UNION ALL
+    SELECT 'voucher_detail',                 COUNT(*)              FROM finance_tst.voucher_detail    UNION ALL
+    SELECT 'accounts_payable',               COUNT(*)              FROM finance_tst.accounts_payable  UNION ALL
+    SELECT 'asset_transfer',                 COUNT(*)              FROM finance_tst.asset_transfer
+) counts
+ORDER BY table_name;


### PR DESCRIPTION
## Summary
This PR makes the app use `finance_tst` in testing environments while keeping authentication on `finance.user`, and includes a small set of voucher-entry UI fixes.

## Changes
- add environment-aware SQLAlchemy Base schema selection
- keep `User` mapped to `finance.user` for auth in TECHTEST
- add scripts/Make target to recreate and load `finance_tst`
- default voucher type to Paper receipt
- make voucher entry tab order explicit through Submit
- add TECHTEST/PRODUCTION badge in the nav bar
- improve initial focus and Enter-submit behavior on voucher entry

## Validation
- recreated and loaded `finance_tst` from live `finance` data subset
- verified schema switching for testing vs non-testing
- verified `User` remains on `finance`
- UI retested for badge, default type, and tab order

Closes #34
Closes #35
Closes #23
Closes #24
Closes #28